### PR TITLE
Set engines to allow node4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "6"
+  - "4"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/mathiasbynens/unicode-property-aliases",
   "main": "index.js",
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   },
   "files": [
     "LICENSE-MIT.txt",


### PR DESCRIPTION
While fixing tests for https://github.com/babel/babel-preset-env/pull/182 (which brings in babel-plugin-transform-es2015-unicode-regex@7.0.0-alpha.1), we ran into a case where yarn fails on node4 due to the engine set here.

```sh
error unicode-property-aliases@1.1.0: The engine "node" is incompatible with this module. Expected version ">=6".
error Found incompatible module
```

The tests pass, but is there anything I'm missing that might require 6+?